### PR TITLE
V2.0.1- Add and modify rules

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,10 @@
 
 **Released - 11 Apr, 2024**
 
-- Add [array-element-newline](https://eslint.style/rules/default/array-element-newline), [space-infix-ops](https://eslint.style/rules/default/sace-infix-ops) rules in `js` config.
+- Add the following rules in `js` config
+  - [array-element-newline](https://eslint.style/rules/default/array-element-newline)
+  - [space-before-blocks](https://eslint.style/rules/default/space-before-blocks)
+  - [space-infix-ops](https://eslint.style/rules/default/sace-infix-ops)
 - Modify [comma-dangle](https://eslint.style/rules/default/comma-dangle) config.
 
 ## [2.0.0](https://github.com/nishkohli96/eslint-config/tree/v2.0.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 
 - Add the following rules in `js` config
   - [array-element-newline](https://eslint.style/rules/default/array-element-newline)
+  - [newline-per-chained-call](https://eslint.style/rules/default/newline-per-chained-call)
   - [space-before-blocks](https://eslint.style/rules/default/space-before-blocks)
   - [space-infix-ops](https://eslint.style/rules/default/sace-infix-ops)
 - Modify [comma-dangle](https://eslint.style/rules/default/comma-dangle) config.

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 **Released - 11 Apr, 2024**
 
-- Add [array-element-newline](https://eslint.style/rules/default/array-element-newline) rule in `js` config.
+- Add [array-element-newline](https://eslint.style/rules/default/array-element-newline), [space-infix-ops](https://eslint.style/rules/default/sace-infix-ops) rules in `js` config.
 - Modify [comma-dangle](https://eslint.style/rules/default/comma-dangle) config.
 
 ## [2.0.0](https://github.com/nishkohli96/eslint-config/tree/v2.0.0)

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # **What's changed?**
 
+## [2.0.1](https://github.com/nishkohli96/eslint-config/tree/v2.0.1)
+
+**Released - 11 Apr, 2024**
+
+- Add [array-element-newline](https://eslint.style/rules/default/array-element-newline) rule in `js` config.
+
 ## [2.0.0](https://github.com/nishkohli96/eslint-config/tree/v2.0.0)
 
 **Released - 10 Apr, 2024**

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 **Released - 11 Apr, 2024**
 
 - Add the following rules in `js` config
+  - [@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)
   - [array-element-newline](https://eslint.style/rules/default/array-element-newline)
   - [newline-per-chained-call](https://eslint.style/rules/default/newline-per-chained-call)
   - [space-before-blocks](https://eslint.style/rules/default/space-before-blocks)

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 **Released - 11 Apr, 2024**
 
 - Add [array-element-newline](https://eslint.style/rules/default/array-element-newline) rule in `js` config.
+- Modify [comma-dangle](https://eslint.style/rules/default/comma-dangle) config.
 
 ## [2.0.0](https://github.com/nishkohli96/eslint-config/tree/v2.0.0)
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ All rule names start with `@stylistic/` prefix.
 |[arrow-spacing](https://eslint.style/rules/default/arrow-spacing)||
 |[block-spacing](https://eslint.style/rules/default/block-spacing)||
 |[brace-style](https://eslint.style/rules/default/brace-style)||
-|[comma-dangle](https://eslint.style/rules/default/comma-dangle)|
-{ arrays: 'always', objects: 'always', imports: 'never', exports: 'never' functions: 'never' } |
+|[comma-dangle](https://eslint.style/rules/default/comma-dangle)| { arrays: 'always', objects: 'always', imports: 'never', exports: 'never' functions: 'never' } |
 |[comma-spacing](https://eslint.style/rules/default/comma-spacing)||
 |[eol-last](https://eslint.style/rules/default/eol-last)||
 |[function-call-argument-newline](https://eslint.style/rules/default/function-call-argument-newline)| consistent |
@@ -162,8 +161,7 @@ All rule names start with `@stylistic/` prefix.
 |[quotes](https://eslint.style/rules/default/quotes)| single |
 |[rest-spread-spacing](https://eslint.style/rules/default/rest-spread-spacing)||
 |[semi-spacing](https://eslint.style/rules/default/semi-spacing)||
-|[space-before-blocks](https://eslint.style/rules/default/space-before-blocks)|
-{ functions: 'always', classes: 'always', keywords: 'never' } |
+|[space-before-blocks](https://eslint.style/rules/default/space-before-blocks)| { functions: 'always', classes: 'always', keywords: 'never' } |
 |[space-infix-ops](https://eslint.style/rules/default/space-infix-ops)||
 |[space-unary-ops](https://eslint.style/rules/default/space-unary-ops)||
 |[spaced-comment](https://eslint.style/rules/default/spaced-comment)||
@@ -218,6 +216,7 @@ The eslint rule(s) listed below will give an error and will have to be manually 
 
 | Rule Name | Status |
 |-|-|
+|[@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/) | warn |
 |[no-unused-vars](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-ts-comment.md) | warn |
 |[no-this-alias](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-this-alias.mdx) | off |
 
@@ -268,7 +267,7 @@ You will need to manually add them in the `rules` of your .eslintrc, if needed.
 |-|-|
 |[jsx-first-prop-new-line](https://eslint.style/rules/default/jsx-first-prop-new-line)| |
 |[@stylistic/lines-around-comment](https://eslint.style/rules/default/lines-around-comment)| Sometimes reqd, when writing block comments above functions, but don't need when writing block comment between 2 lines of code |
-|[@typescript-eslint/ban-ts-comment](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx) |
+|[@typescript-eslint/ban-ts-comment](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-ts-comment.mdx) | A good developer will avoid writing ts-comments, except in extreme cases. Let's not cause them trouble to write one more line |
 |[@typescript-eslint/no-this-alias](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-this-alias.md) | sometimes `this` is reqd in fn context. eg. MongooseSchema.pre() |
 |[id-denylist](https://eslint.org/docs/latest/rules/id-denylist) | use if required. eg. "id-denylist": ["warn", "e", "cb", 'callback']|
 [id-length](https://eslint.org/docs/latest/rules/id-length)| warning when using `_` for unused vars |

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ All rule names start with `@stylistic/` prefix.
 |[indent-binary-ops](https://eslint.style/rules/default/indent-binary-ops)| 2 |
 |[key-spacing](https://eslint.style/rules/default/key-spacing)||
 |[linebreak-style](https://eslint.style/rules/default/linebreak-style)||
+|[newline-per-chained-call](https://eslint.style/rules/default/newline-per-chained-call)||
 |[no-extra-semi](https://eslint.style/rules/default/no-extra-semi)||
 |[no-floating-decimal](https://eslint.style/rules/default/no-floating-decimal)||
 |[no-mixed-spaces-and-tabs](https://eslint.style/rules/default/no-mixed-spaces-and-tabs)||

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To add a new rule, turn off or modify the existing list of rules, append the `ru
 }
 ```
 
-To disable one or more rules throughout the file,
+To disable one or more rules throughout the file, add this at the top of your file.
 ```
 /* eslint-disable  @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any */
 ```
@@ -108,7 +108,7 @@ npm run lint
 yarn lint
 ```
 
-For formatting non-js like `.css, .html` files you can use prettier alongside eslint. Prettier configuration, prettierignore and usage of eslint with prettier in `pre-commit` hook can be referenced from my [react-node-ts-monorepo](https://github.com/nishkohli96/react-node-ts-monorepo/tree/main).
+For formatting non-js like `.css, .html` files you can use prettier alongside eslint. Prettier configuration, prettierignore and usage of eslint with prettier in `pre-commit` hook can be referenced from my [react-node-ts-monorepo](https://github.com/nishkohli96/react-node-ts-monorepo/blob/main/package.json).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This config extends the following plugins and parsers -
 
 ## Installation
 
-You'll first need to install [ESLint](https://eslint.org/). If you project is a monorepo, add a `-W` flag to each of the commands below.
+You'll first need to install [ESLint](https://eslint.org/). If you project is a monorepo, consider creating a separate eslint-config for each package.
 
 ```
 npm i eslint --save-dev

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ All rule names start with `@stylistic/` prefix.
 |[operator-linebreak](https://eslint.style/rules/default/operator-linebreak)| before |
 |[quotes](https://eslint.style/rules/default/quotes)| single |
 |[rest-spread-spacing](https://eslint.style/rules/default/rest-spread-spacing)||
+|[space-infix-ops](https://eslint.style/rules/default/sace-infix-ops)||
 |[space-unary-ops](https://eslint.style/rules/default/sace-unary-ops)||
 |[semi-spacing](https://eslint.style/rules/default/semi-spacing)||
 |[spaced-comment](https://eslint.style/rules/default/spaced-comment)||

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ All rule names start with `@stylistic/` prefix.
 |-|-|
 |[array-bracket-newline](https://eslint.style/rules/default/array-bracket-newline)| { multiline: true, minItems: 4 } |
 |[array-bracket-spacing](https://eslint.style/rules/default/array-bracket-spacing)||
+|[array-element-newline](https://eslint.style/rules/default/array-element-newline)| { multiline: true, minItems: 4 } |
 |[arrow-parens](https://eslint.style/rules/default/arrow-parens)| as-needed |
 |[arrow-spacing](https://eslint.style/rules/default/arrow-spacing)||
 |[block-spacing](https://eslint.style/rules/default/block-spacing)||

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ All rule names start with `@stylistic/` prefix.
 |[arrow-spacing](https://eslint.style/rules/default/arrow-spacing)||
 |[block-spacing](https://eslint.style/rules/default/block-spacing)||
 |[brace-style](https://eslint.style/rules/default/brace-style)||
-|[comma-dangle](https://eslint.style/rules/default/comma-dangle)||  always-multiline |
+|[comma-dangle](https://eslint.style/rules/default/comma-dangle)|
+{ arrays: 'always', objects: 'always', imports: 'never', exports: 'never' functions: 'never' } |
 |[comma-spacing](https://eslint.style/rules/default/comma-spacing)||
 |[eol-last](https://eslint.style/rules/default/eol-last)||
 |[function-call-argument-newline](https://eslint.style/rules/default/function-call-argument-newline)| consistent |

--- a/README.md
+++ b/README.md
@@ -160,9 +160,11 @@ All rule names start with `@stylistic/` prefix.
 |[operator-linebreak](https://eslint.style/rules/default/operator-linebreak)| before |
 |[quotes](https://eslint.style/rules/default/quotes)| single |
 |[rest-spread-spacing](https://eslint.style/rules/default/rest-spread-spacing)||
-|[space-infix-ops](https://eslint.style/rules/default/sace-infix-ops)||
-|[space-unary-ops](https://eslint.style/rules/default/sace-unary-ops)||
 |[semi-spacing](https://eslint.style/rules/default/semi-spacing)||
+|[space-before-blocks](https://eslint.style/rules/default/space-before-blocks)|
+{ functions: 'always', classes: 'always', keywords: 'never' } |
+|[space-infix-ops](https://eslint.style/rules/default/space-infix-ops)||
+|[space-unary-ops](https://eslint.style/rules/default/space-unary-ops)||
 |[spaced-comment](https://eslint.style/rules/default/spaced-comment)||
 |[switch-colon-spacing](https://eslint.style/rules/default/switch-colon-spacing)||
 |[template-curly-spacing](https://eslint.style/rules/default/template-curly-spacing)||

--- a/__tests__/bad-js.js
+++ b/__tests__/bad-js.js
@@ -9,8 +9,9 @@ const obj = { name: 'john', age: 36}
 function someFN(var1,var2,var3) {return var1-var2+var3}
 
 let arr = [2,42,42,33,23,67,234,2323]
-
 arr.forEach(ele => ele+=1)
+
+var arr2 = ['raj', 'rajesh', 'rajesh kumar']
 
 // const element = () => {
 // 	return (

--- a/__tests__/bad-js.js
+++ b/__tests__/bad-js.js
@@ -6,6 +6,8 @@ const func = (e) => console.log('some function');
 
 const obj = { name: 'john', age: 36}
 
+const res = a?b:c
+
 function someFN(var1,var2,var3) {return var1-var2+var3}
 
 let arr = [2,42,42,33,23,67,234,2323]

--- a/__tests__/bad-js.js
+++ b/__tests__/bad-js.js
@@ -1,5 +1,9 @@
 var st = "122"
 
+var tryq = '2463'
+tryq.toLowerCase().replace('1','8')
+tryq.toLowerCase().replace('1','8').split('').map(el => `-${el}-`)
+
 const func = (e) => console.log('some function');
 
 

--- a/__tests__/bad-js.js
+++ b/__tests__/bad-js.js
@@ -8,6 +8,9 @@ const obj = { name: 'john', age: 36}
 
 function someFN(var1,var2,var3) {return var1-var2+var3}
 
+let arr = [2,42,42,33,23,67,234,2323]
+
+arr.forEach(ele => ele+=1)
 
 // const element = () => {
 // 	return (

--- a/__tests__/bad-js.js
+++ b/__tests__/bad-js.js
@@ -8,7 +8,16 @@ const obj = { name: 'john', age: 36}
 
 const res = a?b:c
 
-function someFN(var1,var2,var3) {return var1-var2+var3}
+function a(){}
+function someFN(var1,var2,var3){return var1-var2+var3}
+
+class Foo{
+  constructor(){}
+}
+
+for (;;) {
+  // ...
+}
 
 let arr = [2,42,42,33,23,67,234,2323]
 arr.forEach(ele => ele+=1)

--- a/__tests__/bad-jsx.js
+++ b/__tests__/bad-jsx.js
@@ -1,3 +1,4 @@
+import { Button, Grid, Radio, FormControl } from '@mui/material';
 const element = () => {
 	return (
 		<div>

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -24,6 +24,10 @@ module.exports = {
       { multiline: true, minItems: 4 },
     ],
     '@stylistic/array-bracket-spacing': 'warn',
+    '@stylistic/array-element-newline': [
+      'warn',
+      { multiline: true, minItems: 4 },
+    ],
     '@stylistic/arrow-parens': ['warn', 'as-needed'],
     '@stylistic/arrow-spacing': 'warn',
     '@stylistic/block-spacing': 'warn',

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -47,6 +47,7 @@ module.exports = {
     '@stylistic/indent-binary-ops': ['warn', 2],
     '@stylistic/key-spacing': 'warn',
     '@stylistic/linebreak-style': 'warn',
+    '@stylistic/newline-per-chained-call': 'warn',
     '@stylistic/no-extra-semi': 'warn',
     '@stylistic/no-floating-decimal': 'warn',
     '@stylistic/no-mixed-operators': 'error',

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -32,7 +32,13 @@ module.exports = {
     '@stylistic/arrow-spacing': 'warn',
     '@stylistic/block-spacing': 'warn',
     '@stylistic/brace-style': 'warn',
-    '@stylistic/comma-dangle': ['warn', 'always-multiline'],
+    '@stylistic/comma-dangle': ['warn', {
+      arrays: 'always',
+      objects: 'always',
+      imports: 'never',
+      exports: 'never',
+      functions: 'never'
+    }],
     '@stylistic/comma-spacing': 'warn',
     '@stylistic/eol-last': 'warn',
     '@stylistic/function-call-argument-newline': ['warn', 'consistent'],

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -83,6 +83,7 @@ module.exports = {
     '@stylistic/type-named-tuple-spacing': 'warn',
     '@stylistic/wrap-regex': 'warn',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',
     '@typescript-eslint/no-this-alias': 'off',
     'array-callback-return': 'warn',

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -62,6 +62,7 @@ module.exports = {
     '@stylistic/rest-spread-spacing': 'warn',
     '@stylistic/semi-spacing': 'warn',
     '@stylistic/spaced-comment': 'warn',
+    '@stylistic/space-infix-ops': 'warn',
     '@stylistic/space-unary-ops': [
       'warn',
       {

--- a/lib/js/index.js
+++ b/lib/js/index.js
@@ -61,7 +61,11 @@ module.exports = {
     '@stylistic/quotes': ['warn', 'single'],
     '@stylistic/rest-spread-spacing': 'warn',
     '@stylistic/semi-spacing': 'warn',
-    '@stylistic/spaced-comment': 'warn',
+    '@stylistic/space-before-blocks': ['warn', {
+      functions: 'always',
+      classes: 'always',
+      keywords: 'never'
+    }],
     '@stylistic/space-infix-ops': 'warn',
     '@stylistic/space-unary-ops': [
       'warn',
@@ -70,6 +74,7 @@ module.exports = {
         nonwords: false,
       },
     ],
+    '@stylistic/spaced-comment': 'warn',
     '@stylistic/switch-colon-spacing': 'warn',
     '@stylistic/template-curly-spacing': 'warn',
     '@stylistic/type-annotation-spacing': 'warn',

--- a/lib/react/index.js
+++ b/lib/react/index.js
@@ -47,8 +47,13 @@ module.exports = {
         return: 'parens-new-line',
       },
     ],
+    '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-this-alias': 'off',
+    '@typescript-eslint/no-unused-vars': 'warn',
     'jsx-a11y/anchor-ambiguous-text': 'error',
     'jsx-a11y/control-has-associated-label': 'error',
+    'no-mixed-spaces-and-tabs': 'off',
     'react/react-in-jsx-scope': 'off',
     'react/jsx-uses-vars': 'error',
     'react/jsx-filename-extension': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/eslint-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "eslint and stylistic rules to help you focus more on the code logic, while they take care of the code formatting",
   "author": "Nishant Kohli",
   "exports": {


### PR DESCRIPTION
- Add the following rules in `js` config
  - [@typescript-eslint/no-explicit-any](https://typescript-eslint.io/rules/no-explicit-any/)
  - [array-element-newline](https://eslint.style/rules/default/array-element-newline)
  - [newline-per-chained-call](https://eslint.style/rules/default/newline-per-chained-call)
  - [space-before-blocks](https://eslint.style/rules/default/space-before-blocks)
  - [space-infix-ops](https://eslint.style/rules/default/sace-infix-ops)
- Modify [comma-dangle](https://eslint.style/rules/default/comma-dangle) config.