### PR TITLE
v1.1.2_flat-config - Fix ignores error

### DIFF
--- a/packages/eslint-flat-config/lib/js/index.mjs
+++ b/packages/eslint-flat-config/lib/js/index.mjs
@@ -16,16 +16,9 @@ export default [
     },
   },
 
-  /* File and ignore patterns */
+  /* Target Files */
   {
     files: ['**/*.{js,mjs,cjs,ts}'],
-    ignores: [
-      'node_modules',
-      'dist',
-      'build',
-      'coverage',
-      '.turbo',
-    ]
   },
   /* Recommended Configs */
   js.configs.recommended,
@@ -123,5 +116,19 @@ export default [
       'require-await': 'warn',
       'use-isnan': 'warn',
     }
+  },
+  /**
+   * Ignore linting the below folders...
+   * "ignores" needs to be written at last, else linting 
+   * would also run on build folders. 
+   */
+  {
+    ignores: [
+      'node_modules',
+      'dist',
+      'build',
+      'coverage',
+      '.turbo',
+    ]
   }
 ];

--- a/packages/eslint-flat-config/lib/jsx/index.mjs
+++ b/packages/eslint-flat-config/lib/jsx/index.mjs
@@ -24,19 +24,9 @@ export default [
     },
   },
 
-  /* File and ignore patterns */
+  /* Target Files */
   {
     files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
-    ignores: [
-      'node_modules',
-      'dist',
-      'build',
-      'coverage',
-      '.next',
-      '.turbo',
-      '.eslintcache',
-      'storybook-static',
-    ],
   },
 
   /* Recommended Configs */
@@ -82,5 +72,17 @@ export default [
         },
       ],
     }
+  },
+  {
+    ignores: [
+      'node_modules',
+      'dist',
+      'build',
+      'coverage',
+      '.next',
+      '.turbo',
+      '.eslintcache',
+      'storybook-static',
+    ],
   }
 ];

--- a/packages/eslint-flat-config/lib/next/index.mjs
+++ b/packages/eslint-flat-config/lib/next/index.mjs
@@ -39,19 +39,9 @@ export default [
     },
   },
 
-  /* File and ignore patterns */
+  /* Target Files */
   {
     files: ['**/*.{js,mjs,cjs,ts,jsx,tsx}'],
-    ignores: [
-      'node_modules',
-      'dist',
-      'build',
-      'coverage',
-      '.next',
-      '.turbo',
-      '.eslintcache',
-      'storybook-static',
-    ],
   },
 
   /* Recommended Configs */
@@ -151,4 +141,16 @@ export default [
       'use-isnan': 'warn',
     },
   },
+  {
+    ignores: [
+      'node_modules',
+      'dist',
+      'build',
+      'coverage',
+      '.next',
+      '.turbo',
+      '.eslintcache',
+      'storybook-static',
+    ],
+  }
 ];

--- a/packages/eslint-flat-config/package.json
+++ b/packages/eslint-flat-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nish1896/eslint-flat-config",
-  "version": "1.1.1",
-  "description": "eslint and stylistic rules for eslint v9 and above to take care of the code formatting.",
+  "version": "1.1.2",
+  "description": "Linting rules configured for ESLint v9 and above to ensure consistent code formatting.",
   "author": "Nishant Kohli",
   "engines": {
     "node": ">=18.18.0 || >=20.9.0 || >=21"


### PR DESCRIPTION
Move back **"ignores"** key under `rules` for each flat-config file as it was causing linting to also apply on build files.