### PR TITLE
v3.0.2 - Update "@typescript-eslint/consistent-type-imports" rule

### DIFF
--- a/apps/eslint-config-docs/docs/changelog/v3.0.md
+++ b/apps/eslint-config-docs/docs/changelog/v3.0.md
@@ -7,6 +7,16 @@ title: Changelog-v3
 
 # **What's changed?**
 
+## [3.0.2](https://github.com/nishkohli96/eslint-config/tree/v3.0.2)
+
+**Released - 31 March, 2025**
+
+### Minor Bug Fix 🔧🐞
+
+- Update [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/) rule to add `type` prefix inline, thus preventing conflict with [no-duplicate-imports](https://eslint.org/docs/latest/rules/no-duplicate-imports)
+- Update [@typescript-eslint/consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors/) in **eslint-config** package
+
+
 ## [3.0.1](https://github.com/nishkohli96/eslint-config/tree/v3.0.1)
 
 **Released - 31 March, 2025**

--- a/apps/eslint-config-docs/package.json
+++ b/apps/eslint-config-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/eslint-config-docs",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/eslint-config-root",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "eslint and stylistic rules to help you focus more on the code logic, while they take care of the code formatting",
   "author": "Nishant Kohli",
   "private": true,

--- a/packages/eslint-config/lib/next-ts/index.js
+++ b/packages/eslint-config/lib/next-ts/index.js
@@ -56,10 +56,16 @@ module.exports = {
     '@stylistic/plus/type-named-tuple-spacing': 'warn',
     '@typescript-eslint/array-type': 'warn',
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/consistent-generic-constructors': 'warn',
+    '@typescript-eslint/consistent-generic-constructors': [
+      'warn',
+      'constructor'
+    ],
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-exports': 'warn',
-    '@typescript-eslint/consistent-type-imports': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      { fixStyle: 'inline-type-imports' }
+    ],
     '@typescript-eslint/no-base-to-string': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-floating-promises': 'off',

--- a/packages/eslint-config/lib/ts/index.js
+++ b/packages/eslint-config/lib/ts/index.js
@@ -46,10 +46,16 @@ module.exports = {
     '@stylistic/plus/type-named-tuple-spacing': 'warn',
     '@typescript-eslint/array-type': 'warn',
     '@typescript-eslint/ban-ts-comment': 'off',
-    '@typescript-eslint/consistent-generic-constructors': 'warn',
+    '@typescript-eslint/consistent-generic-constructors': [
+      'warn',
+      'constructor'
+    ],
     '@typescript-eslint/consistent-type-definitions': 'off',
     '@typescript-eslint/consistent-type-exports': 'warn',
-    '@typescript-eslint/consistent-type-imports': 'warn',
+    '@typescript-eslint/consistent-type-imports': [
+      'warn',
+      { fixStyle: 'inline-type-imports' }
+    ],
     '@typescript-eslint/no-base-to-string': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-floating-promises': 'off',

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/eslint-config",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "eslint and stylistic rules for eslint 8.57.0 or below to catch potential errors and take care of the code formatting.",
   "author": "Nishant Kohli",
   "exports": {

--- a/packages/eslint-flat-config/lib/next-ts/index.mjs
+++ b/packages/eslint-flat-config/lib/next-ts/index.mjs
@@ -61,10 +61,16 @@ const nextTsConfig = [
       '@stylistic/plus/type-named-tuple-spacing': 'warn',
       '@typescript-eslint/array-type': 'warn',
       '@typescript-eslint/ban-ts-comment': 'off',
-      '@typescript-eslint/consistent-generic-constructors': ['warn', 'constructor'],
+      '@typescript-eslint/consistent-generic-constructors': [
+        'warn',
+        'constructor'
+      ],
       '@typescript-eslint/consistent-type-definitions': 'off',
       '@typescript-eslint/consistent-type-exports': 'warn',
-      '@typescript-eslint/consistent-type-imports': 'warn',
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { fixStyle: 'inline-type-imports' }
+      ],
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-floating-promises': 'off',

--- a/packages/eslint-flat-config/lib/ts/index.mjs
+++ b/packages/eslint-flat-config/lib/ts/index.mjs
@@ -50,10 +50,16 @@ const tsConfig = [
       '@stylistic/plus/type-named-tuple-spacing': 'warn',
       '@typescript-eslint/array-type': 'warn',
       '@typescript-eslint/ban-ts-comment': 'off',
-      '@typescript-eslint/consistent-generic-constructors': ['warn', 'constructor'],
+      '@typescript-eslint/consistent-generic-constructors': [
+        'warn',
+        'constructor'
+      ],
       '@typescript-eslint/consistent-type-definitions': 'off',
       '@typescript-eslint/consistent-type-exports': 'warn',
-      '@typescript-eslint/consistent-type-imports': 'warn',
+      '@typescript-eslint/consistent-type-imports': [
+        'warn',
+        { fixStyle: 'inline-type-imports' }
+      ],
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-floating-promises': 'off',

--- a/packages/eslint-flat-config/package.json
+++ b/packages/eslint-flat-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nish1896/eslint-flat-config",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Linting rules configured for ESLint v9 and above to catch potential errors and ensure consistent code formatting.",
   "author": "Nishant Kohli",
   "engines": {


### PR DESCRIPTION
- Update [@typescript-eslint/consistent-type-imports](https://typescript-eslint.io/rules/consistent-type-imports/) rule to add `type` prefix inline, thus preventing conflict with [no-duplicate-imports](https://eslint.org/docs/latest/rules/no-duplicate-imports)
- Update [@typescript-eslint/consistent-generic-constructors](https://typescript-eslint.io/rules/consistent-generic-constructors/) in **eslint-config** package